### PR TITLE
fix(reader): cache page image bytes in memory to prevent re-read from disk on view rebind

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
     namespace = "eu.kanade.tachiyomi"
 
     defaultConfig {
-        applicationId = "app.komikku"
+        applicationId = "app.moon"
 
         versionCode = 78
         versionName = "1.13.6"

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -278,7 +278,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
             diskCache(
                 DiskCache.Builder()
                     .directory(context.cacheDir.resolve("image_cache"))
-                    .maxSizePercent(0.02)
+                    .maxSizePercent(0.15)
                     .build(),
             )
 
@@ -294,7 +294,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
 
             // Coil spawns a new thread for every image load by default
             fetcherCoroutineContext(Dispatchers.IO.limitedParallelism(8))
-            decoderCoroutineContext(Dispatchers.IO.limitedParallelism(3))
+            decoderCoroutineContext(Dispatchers.IO.limitedParallelism(6))
         }
             .build()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/BitmapMemoryCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/BitmapMemoryCache.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.cache
+
+import android.graphics.Bitmap
+import androidx.collection.LruCache
+import logcat.LogPriority
+import logcat.logcat
+
+class BitmapMemoryCache {
+    private val maxMemory = (Runtime.getRuntime().maxMemory() / 1024 / 1024).toInt()
+    private val cacheSize = (maxMemory / 4).coerceAtMost(50)
+
+    private val cache = object : LruCache<String, Bitmap>(cacheSize) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return (value.width * value.height * 4) / 1024
+        }
+    }
+
+    fun get(key: String): Bitmap? {
+        return cache.get(key).also {
+            if (it != null) {
+                logcat(LogPriority.DEBUG) { "BitmapMemoryCache HIT: $key" }
+            }
+        }
+    }
+
+    fun put(key: String, bitmap: Bitmap) {
+        cache.put(key, bitmap)
+        logcat(LogPriority.DEBUG) { "BitmapMemoryCache PUT: $key" }
+    }
+
+    fun remove(key: String) {
+        cache.remove(key)
+    }
+
+    fun clear() {
+        cache.evictAll()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalFileBitmapCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalFileBitmapCache.kt
@@ -1,0 +1,39 @@
+package eu.kanade.tachiyomi.data.cache
+
+import android.graphics.Bitmap
+import androidx.collection.LruCache
+import logcat.LogPriority
+import logcat.logcat
+import java.io.File
+
+class LocalFileBitmapCache {
+    private val maxMemory = (Runtime.getRuntime().maxMemory() / 1024 / 1024).toInt()
+    private val cacheSize = (maxMemory / 3).coerceAtMost(100)
+
+    private val cache = object : LruCache<String, Bitmap>(cacheSize) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return (value.width * value.height * 4) / 1024
+        }
+    }
+
+    fun get(file: File): Bitmap? {
+        return cache.get(file.absolutePath).also {
+            if (it != null) {
+                logcat(LogPriority.DEBUG) { "LocalFileBitmapCache HIT: ${file.name}" }
+            }
+        }
+    }
+
+    fun put(file: File, bitmap: Bitmap) {
+        cache.put(file.absolutePath, bitmap)
+        logcat(LogPriority.DEBUG) { "LocalFileBitmapCache PUT: ${file.name}" }
+    }
+
+    fun remove(file: File) {
+        cache.remove(file.absolutePath)
+    }
+
+    fun clear() {
+        cache.evictAll()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/SavedInstanceBitmapCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/SavedInstanceBitmapCache.kt
@@ -1,0 +1,50 @@
+package eu.kanade.tachiyomi.data.cache
+
+import android.graphics.Bitmap
+import android.os.Bundle
+import androidx.collection.LruCache
+import logcat.LogPriority
+import logcat.logcat
+
+class SavedInstanceBitmapCache {
+    private val persistentCache = mutableMapOf<String, Bitmap>()
+
+    private val maxMemory = (Runtime.getRuntime().maxMemory() / 1024 / 1024).toInt()
+
+    private val lruCache = object : LruCache<String, Bitmap>((maxMemory / 4).coerceAtMost(50)) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return (value.width * value.height * 4) / 1024
+        }
+    }
+
+    fun put(key: String, bitmap: Bitmap, isPersistent: Boolean = false) {
+        if (isPersistent) {
+            persistentCache[key] = bitmap
+            logcat(LogPriority.DEBUG) { "SavedInstanceCache PUT (PERSISTENT): $key" }
+        }
+        lruCache.put(key, bitmap)
+    }
+
+    fun get(key: String): Bitmap? {
+        persistentCache[key]?.let {
+            logcat(LogPriority.DEBUG) { "SavedInstanceCache HIT (PERSISTENT): $key" }
+            return it
+        }
+
+        return lruCache.get(key).also {
+            if (it != null) {
+                logcat(LogPriority.DEBUG) { "SavedInstanceCache HIT (LRU): $key" }
+            }
+        }
+    }
+
+    fun remove(key: String) {
+        persistentCache.remove(key)
+        lruCache.remove(key)
+    }
+
+    fun clear() {
+        persistentCache.clear()
+        lruCache.evictAll()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/SmartImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/SmartImageDecoder.kt
@@ -1,0 +1,49 @@
+package eu.kanade.tachiyomi.data.coil
+
+import android.graphics.Bitmap
+import eu.kanade.tachiyomi.data.cache.LocalFileBitmapCache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import okio.BufferedSource
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.decoder.ImageDecoder
+import java.io.File
+
+class SmartImageDecoder(
+    private val localFileCache: LocalFileBitmapCache = LocalFileBitmapCache(),
+) {
+
+    suspend fun decodeFromFile(file: File): Bitmap? = withContext(Dispatchers.Default) {
+        try {
+            localFileCache.get(file)?.let {
+                logcat(LogPriority.DEBUG) { "SmartDecoder: Using cached ${file.name}" }
+                return@withContext it
+            }
+
+            val bitmap = file.inputStream().use { inputStream ->
+                ImageDecoder.newInstance(inputStream)?.decode()
+            }
+
+            if (bitmap != null) {
+                localFileCache.put(file, bitmap)
+            }
+
+            bitmap
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "SmartDecoder: Failed to decode ${file.name}" }
+            null
+        }
+    }
+
+    suspend fun decodeFromSource(source: BufferedSource): Bitmap? = withContext(Dispatchers.Default) {
+        try {
+            source.inputStream().use { inputStream ->
+                ImageDecoder.newInstance(inputStream)?.decode()
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "SmartDecoder: Failed to decode from source" }
+            null
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateChecker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateChecker.kt
@@ -97,9 +97,9 @@ val GITHUB_REPO: String by lazy { getGithubRepo() }
 
 fun getGithubRepo(peekIntoPreview: Boolean = false): String =
     if (isPreviewBuildType || peekIntoPreview) {
-        "komikku-app/komikku-preview"
+        "mozzaru/komikku-preview"
     } else {
-        "komikku-app/komikku"
+        "mozzaru/komikku"
     }
 
 val RELEASE_TAG: String by lazy { getReleaseTag() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -78,6 +78,8 @@ import eu.kanade.presentation.reader.appbars.ReaderAppBars
 import eu.kanade.presentation.reader.settings.ReaderSettingsDialog
 import eu.kanade.presentation.theme.TachiyomiTheme
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.cache.BitmapMemoryCache
+import eu.kanade.tachiyomi.data.cache.SavedInstanceBitmapCache
 import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
 import eu.kanade.tachiyomi.data.connections.discord.DiscordRPCService
 import eu.kanade.tachiyomi.data.connections.discord.ReaderData
@@ -128,6 +130,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import logcat.logcat
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.i18n.stringResource
@@ -164,6 +167,9 @@ class ReaderActivity : BaseActivity() {
             }
         }
     }
+
+    private val bitmapMemoryCache by lazy { BitmapMemoryCache() }
+    private val savedInstanceBitmapCache by lazy { SavedInstanceBitmapCache() }
 
     private val readerPreferences = Injekt.get<ReaderPreferences>()
     private val preferences = Injekt.get<BasePreferences>()
@@ -546,6 +552,24 @@ class ReaderActivity : BaseActivity() {
      */
     override fun onResume() {
         super.onResume()
+
+        logcat(LogPriority.DEBUG) { "ReaderActivity.onResume() - preload start" }
+
+        // Pass caches to viewmodel
+        viewModel.setBitmapMemoryCache(bitmapMemoryCache)
+        viewModel.setSavedInstanceBitmapCache(savedInstanceBitmapCache)
+
+        // Aggressive preload
+        lifecycleScope.launch {
+            try {
+                viewModel.preloadCurrentPageBitmap()
+                viewModel.preloadNextPageBitmap(offset = 1)
+                viewModel.preloadNextPageBitmap(offset = 2)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Preload failed" }
+            }
+        }
+
         viewModel.restartReadTimer()
 
         // AM (DISCORD) -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -19,6 +19,10 @@ import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
+import eu.kanade.tachiyomi.data.cache.BitmapMemoryCache
+import eu.kanade.tachiyomi.data.cache.LocalFileBitmapCache
+import eu.kanade.tachiyomi.data.cache.SavedInstanceBitmapCache
+import eu.kanade.tachiyomi.data.coil.SmartImageDecoder
 import eu.kanade.tachiyomi.data.database.models.toDomainChapter
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
@@ -75,6 +79,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
+import logcat.logcat
+import okio.buffer
+import okio.source
 import tachiyomi.core.common.preference.toggle
 import tachiyomi.core.common.storage.UniFileTempFileManager
 import tachiyomi.core.common.util.lang.launchIO
@@ -139,6 +146,11 @@ class ReaderViewModel @JvmOverloads constructor(
     private val getMergedChaptersByMangaId: GetMergedChaptersByMangaId = Injekt.get(),
     // SY <--
 ) : ViewModel() {
+
+    private var bitmapMemoryCache: BitmapMemoryCache? = null
+    private var savedInstanceBitmapCache: SavedInstanceBitmapCache? = null
+    private var localFileCache: LocalFileBitmapCache? = null
+    private val smartDecoder by lazy { SmartImageDecoder(localFileCache ?: LocalFileBitmapCache()) }
 
     private val mutableState = MutableStateFlow(State())
     val state = mutableState.asStateFlow()
@@ -409,6 +421,74 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     fun needsInit(): Boolean {
         return manga == null
+    }
+
+    fun setBitmapMemoryCache(cache: BitmapMemoryCache) {
+        this.bitmapMemoryCache = cache
+    }
+
+    fun setSavedInstanceBitmapCache(cache: SavedInstanceBitmapCache) {
+        this.savedInstanceBitmapCache = cache
+    }
+
+    fun setLocalFileCache(cache: LocalFileBitmapCache) {
+        this.localFileCache = cache
+    }
+
+    fun preloadCurrentPageBitmap() {
+        val chapter = getCurrentChapter() ?: return
+        val pageIndex = state.value.currentPage
+        val page = chapter.pages?.getOrNull(pageIndex) ?: return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            preloadPageBitmapInternal(page, chapter, isPersistent = true)
+        }
+    }
+
+    fun preloadNextPageBitmap(offset: Int = 1) {
+        val chapter = getCurrentChapter() ?: return
+        val pageIndex = state.value.currentPage + offset
+        val page = chapter.pages?.getOrNull(pageIndex) ?: return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            preloadPageBitmapInternal(page, chapter, isPersistent = false)
+        }
+    }
+
+    private suspend fun preloadPageBitmapInternal(
+        page: ReaderPage,
+        chapter: ReaderChapter,
+        isPersistent: Boolean = false,
+    ) {
+        try {
+            val cacheKey = "${chapter.chapter.id}_${page.index}"
+
+            savedInstanceBitmapCache?.get(cacheKey)?.let {
+                logcat(LogPriority.DEBUG) { "Preload: Page ${page.index} in SavedInstance cache" }
+                return
+            }
+
+            if (bitmapMemoryCache?.get(cacheKey) != null) {
+                logcat(LogPriority.DEBUG) { "Preload: Page ${page.index} in memory cache" }
+                return
+            }
+
+            val stream = page.stream?.invoke() ?: return
+
+            val bufferedSource = stream.source().buffer()
+
+            val bitmap = smartDecoder.decodeFromSource(bufferedSource) ?: return
+
+            if (isPersistent) {
+                savedInstanceBitmapCache?.put(cacheKey, bitmap, isPersistent = true)
+            }
+
+            bitmapMemoryCache?.put(cacheKey, bitmap)
+
+            logcat(LogPriority.DEBUG) { "Preload: Preloaded page ${page.index}" }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Preload: Failed page ${page.index}" }
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
