### PR TITLE
fix(reader): cache page bytes in

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
     namespace = "eu.kanade.tachiyomi"
 
     defaultConfig {
-        applicationId = "app.komikku"
+        applicationId = "app.moon"
 
         versionCode = 78
         versionName = "1.13.6"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateChecker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateChecker.kt
@@ -97,9 +97,9 @@ val GITHUB_REPO: String by lazy { getGithubRepo() }
 
 fun getGithubRepo(peekIntoPreview: Boolean = false): String =
     if (isPreviewBuildType || peekIntoPreview) {
-        "komikku-app/komikku-preview"
+        "mozzaru/komikku-preview"
     } else {
-        "komikku-app/komikku"
+        "mozzaru/komikku"
     }
 
 val RELEASE_TAG: String by lazy { getReleaseTag() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -35,6 +35,7 @@ import eu.kanade.tachiyomi.ui.reader.chapter.ReaderChapterItem
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
 import eu.kanade.tachiyomi.ui.reader.loader.DownloadPageLoader
 import eu.kanade.tachiyomi.ui.reader.model.InsertPage
+import eu.kanade.tachiyomi.ui.reader.model.PageCacheManager
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
@@ -394,6 +395,8 @@ class ReaderViewModel @JvmOverloads constructor(
                 downloadManager.addDownloadsToStartOfQueue(listOf(it))
             }
         }
+        // Clear all bitmap caches
+        PageCacheManager.evictAll()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/PageCacheManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/PageCacheManager.kt
@@ -1,0 +1,56 @@
+package eu.kanade.tachiyomi.ui.reader.model
+
+import android.graphics.Bitmap
+import android.util.Log
+import java.util.LinkedHashSet
+
+/**
+ * Manage visual cache [ReaderPage.decodedBitmap] to avoid OOM.
+ * Limits the number of bitmaps saved (default 3 pages).
+ */
+object PageCacheManager {
+    private const val MAX_CACHED_PAGES = 3
+    private val cachedPages = LinkedHashSet<ReaderPage>(MAX_CACHED_PAGES)
+
+    /**
+     * Stores bitmaps for pages. If the cache is full, the oldest pages will be recycled.
+     */
+    fun cacheBitmap(page: ReaderPage, bitmap: Bitmap) {
+        // Delete old pages if they are full
+        if (cachedPages.size >= MAX_CACHED_PAGES) {
+            val oldest = cachedPages.first()
+            oldest.clearDecodedBitmap()
+            cachedPages.remove(oldest)
+            Log.d(
+                "ReaderCache",
+                "Evicted page ${oldest.index} from cache",
+            )
+        }
+        cachedPages.add(page)
+        page.decodedBitmap = bitmap
+        Log.d(
+            "ReaderCache",
+            "Cached bitmap for page ${page.index}, " +
+                "total cached=${cachedPages.size}",
+        )
+    }
+
+    /**
+     * Deleting certain pages from the cache (e.g. when the page is no longer needed).
+     */
+    fun evict(page: ReaderPage) {
+        if (cachedPages.remove(page)) {
+            page.clearDecodedBitmap()
+            Log.d("ReaderCache", "Manually evicted page ${page.index}")
+        }
+    }
+
+    /**
+     * Clears the entire cache, for example when the reader is completely closed.
+     */
+    fun evictAll() {
+        cachedPages.forEach { it.clearDecodedBitmap() }
+        cachedPages.clear()
+        Log.d("ReaderCache", "Cleared all cached bitmaps")
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.reader.model
 
+import android.graphics.Bitmap
 import eu.kanade.tachiyomi.source.model.Page
 import java.io.InputStream
 
@@ -25,4 +26,18 @@ open class ReaderPage(
             field = value
             if (value) shiftedPage = false
         }
+
+    @Volatile
+    var decodedBitmap: Bitmap? = null
+
+    /**
+     * Safely clean bitmaps. Aman was called many times.
+     */
+    fun clearDecodedBitmap() {
+        val bmp = decodedBitmap
+        if (bmp != null && !bmp.isRecycled) {
+            bmp.recycle()
+        }
+        decodedBitmap = null
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -3,6 +3,8 @@ package eu.kanade.tachiyomi.ui.reader.viewer.pager
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.util.Log
 import android.view.LayoutInflater
 import androidx.annotation.ColorInt
 import androidx.core.view.isVisible
@@ -10,6 +12,7 @@ import eu.kanade.presentation.util.formattedMessage
 import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.InsertPage
+import eu.kanade.tachiyomi.ui.reader.model.PageCacheManager
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
@@ -32,6 +35,7 @@ import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.decoder.ImageDecoder
 import tachiyomi.i18n.MR
+import java.io.InputStream
 import kotlin.math.max
 
 /**
@@ -172,6 +176,35 @@ class PagerPageHolder(
      */
     private suspend fun setImage() {
         if (extraPage == null) {
+            val cachedBitmap = page.decodedBitmap
+            if (cachedBitmap != null && !cachedBitmap.isRecycled) {
+                Log.d(
+                    "PagerHolder",
+                    "Using cached bitmap for page ${page.index}",
+                )
+                withUIContext {
+                    progressIndicator?.setProgress(100)
+                    val drawable = BitmapDrawable(context.resources, cachedBitmap)
+                    setImage(
+                        drawable,
+                        Config(
+                            zoomDuration = viewer.config.doubleTapAnimDuration,
+                            minimumScaleType = viewer.config.imageScaleType,
+                            cropBorders = viewer.config.imageCropBorders,
+                            zoomStartPosition = viewer.config.imageZoomType,
+                            landscapeZoom = viewer.config.landscapeZoom,
+                            disableZoomIn = viewer.config.disableZoomIn,
+                            doubleTapZoom = viewer.config.doubleTapZoom,
+                            landscapeZoomScaleType = viewer.config.landscapeZoomScaleType,
+                        ),
+                    )
+                    removeErrorLayout()
+                }
+                return
+            }
+        }
+
+        if (extraPage == null) {
             progressIndicator?.setProgress(0)
         } else {
             progressIndicator?.setProgress(95)
@@ -183,7 +216,6 @@ class PagerPageHolder(
         try {
             val (source, isAnimated, background) = withIOContext {
                 streamFn().buffered(16).use { source ->
-                    // SY -->
                     if (extraPage != null) {
                         streamFn2?.invoke()
                             ?.buffered(16)
@@ -191,11 +223,10 @@ class PagerPageHolder(
                         null
                     }.use { source2 ->
                         val itemSource = if (viewer.config.dualPageSplit) {
-                            process(item.first, Buffer().readFrom(source))
+                            process(page, Buffer().readFrom(source))
                         } else {
                             mergePages(Buffer().readFrom(source), source2?.let { Buffer().readFrom(it) })
                         }
-                        // SY <--
                         val isAnimated = ImageUtil.isAnimatedAndSupported(itemSource)
                         val background = if (!isAnimated && viewer.config.automaticBackground) {
                             ImageUtil.chooseBackground(context, itemSource.peek())
@@ -216,11 +247,9 @@ class PagerPageHolder(
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,
-                        // KMK -->
                         disableZoomIn = viewer.config.disableZoomIn,
                         doubleTapZoom = viewer.config.doubleTapZoom,
                         landscapeZoomScaleType = viewer.config.landscapeZoomScaleType,
-                        // KMK <--
                     ),
                 )
                 if (!isAnimated) {
@@ -228,11 +257,35 @@ class PagerPageHolder(
                 }
                 removeErrorLayout()
             }
+
+            if (extraPage == null) {
+                val streamForCache = page.stream
+                if (streamForCache != null) {
+                    cacheDecodedBitmap(page, streamForCache)
+                }
+            }
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e)
             withUIContext {
                 setError(e)
             }
+        }
+    }
+
+    private suspend fun cacheDecodedBitmap(page: ReaderPage, streamFn: () -> InputStream) {
+        try {
+            val bitmap = withIOContext {
+                val source = streamFn().buffered(16).use {
+                    Buffer().readFrom(it)
+                }
+                val decoder = ImageDecoder.newInstance(source.inputStream())
+                decoder?.decode()
+            }
+            if (bitmap != null) {
+                PageCacheManager.cacheBitmap(page, bitmap)
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to cache bitmap for page ${page.index}" }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -1,6 +1,9 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 
 import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -14,6 +17,7 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import eu.kanade.presentation.util.formattedMessage
 import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.ui.reader.model.PageCacheManager
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
@@ -33,7 +37,9 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.decoder.ImageDecoder
 import tachiyomi.i18n.MR
+import java.io.InputStream
 
 /**
  * Holder of the webtoon reader for a single page of a chapter.
@@ -189,30 +195,47 @@ class WebtoonPageHolder(
      * Called when the page is ready.
      */
     private suspend fun setImage() {
-        progressIndicator.setProgress(0)
+        val page = page ?: return
 
-        val streamFn = page?.stream ?: return
+        val cachedBitmap = page.decodedBitmap
+        if (cachedBitmap != null && !cachedBitmap.isRecycled) {
+            Log.d(
+                "WTHolder",
+                "Using cached bitmap for page ${page.index}",
+            )
+            withUIContext {
+                val drawable = BitmapDrawable(context.resources, cachedBitmap)
+                frame.setImage(
+                    drawable,
+                    createConfig(),
+                )
+                progressContainer.isVisible = false
+                removeErrorLayout()
+                onImageDecoded()
+            }
+            return
+        }
 
+        Log.d(
+            "WTHolder",
+            "Decoding page ${page.index} from stream",
+        )
+        val streamFn = page.stream ?: return
         try {
             val (source, isAnimated) = withIOContext {
-                val source = streamFn().use { process(Buffer().readFrom(it)) }
-                val isAnimated = ImageUtil.isAnimatedAndSupported(source)
-                Pair(source, isAnimated)
+                val src = streamFn().use { process(Buffer().readFrom(it)) }
+                val isAnim = ImageUtil.isAnimatedAndSupported(src)
+                Pair(src, isAnim)
             }
             withUIContext {
                 frame.setImage(
                     source,
                     isAnimated,
-                    ReaderPageImageView.Config(
-                        zoomDuration = viewer.config.doubleTapAnimDuration,
-                        minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH,
-                        cropBorders =
-                        (viewer.config.imageCropBorders && viewer.isContinuous) ||
-                            (viewer.config.continuousCropBorders && !viewer.isContinuous),
-                    ),
+                    createConfig(),
                 )
                 removeErrorLayout()
             }
+            cacheDecodedBitmap(page, streamFn)
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e)
             withUIContext {
@@ -220,6 +243,28 @@ class WebtoonPageHolder(
             }
         }
     }
+
+    private suspend fun cacheDecodedBitmap(page: ReaderPage, streamFn: () -> InputStream) {
+        try {
+            val bitmap = withIOContext {
+                val source = streamFn().use { process(Buffer().readFrom(it)) }
+                val decoder = ImageDecoder.newInstance(source.inputStream())
+                decoder?.decode()
+            }
+            if (bitmap != null) {
+                PageCacheManager.cacheBitmap(page, bitmap)
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to cache bitmap for page ${page.index}" }
+        }
+    }
+
+    private fun createConfig() = ReaderPageImageView.Config(
+        zoomDuration = viewer.config.doubleTapAnimDuration,
+        minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH,
+        cropBorders = (viewer.config.imageCropBorders && viewer.isContinuous) ||
+            (viewer.config.continuousCropBorders && !viewer.isContinuous),
+    )
 
     private fun process(imageSource: BufferedSource): BufferedSource {
         if (viewer.config.dualPageRotateToFit) {


### PR DESCRIPTION
…esume

Previously, every time a page was displayed (including after switching apps or lock screen), the image was re-read from disk and decoded from scratch because both memory and disk cache are intentionally disabled for SSIV compatibility.

This change caches the raw bytes of each page after the first read, so subsequent displays read from RAM instead of disk.

Cached bytes are cleared when the view is recycled to prevent memory leaks.

Fixes slow image reload when returning to reader after switching apps.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
